### PR TITLE
Draft: Drag and drop multiple files at once

### DIFF
--- a/src/components/PreviewData.tsx
+++ b/src/components/PreviewData.tsx
@@ -162,7 +162,6 @@ const PreviewData = ({ mode }: Props) => {
     useEffect(() => {
         (async () => {
             if (files.length > 0) {
-                console.log("files Debug", files)
                 const data = await chooseCSVParser(files, mode === "CRYPTO" ? parsersCrypto : parsersSecurity)
                 const dataSource = data[0]?.Source
                 if (dataSource === 'Error') {

--- a/src/utils/fifo/fifo.ts
+++ b/src/utils/fifo/fifo.ts
@@ -141,6 +141,7 @@ export function calculateFIFOCapitalGains(
  *
  */
 export const calculateFIFOTransactions = (operationHistory: Operation[]): Transaction[] => {
+  console.log(JSON.stringify(operationHistory.filter(x => x.symbol ==='USDT')))
   const a = calculateFIFOCapitalGains(operationHistory).flatMap((gainByDate) => {
     const totalAmount = _.sumBy(gainByDate.transactions, (o) => o.amountsold)
     const dividedFees = gainByDate.transactions.map(x => ({

--- a/src/utils/parsers/helpers.ts
+++ b/src/utils/parsers/helpers.ts
@@ -20,15 +20,18 @@ const decodeUTF16LE = (binaryStr: string) => {
  */
 const chooseCSVParser = async (filesCopy: FileObject[], parsers: any[]) => {
     const errors: Error[] = []
-    for (let i = 0; i < parsers.length; i++) {
-        try {
-            const inputFile = filesCopy[0].data ? filesCopy[0].data.toString().split(',')[1] : ""
-            const fileContentBuffer = parsers[i].name === 'parseNordNetCSV' ? decodeUTF16LE(atob(inputFile)) : b64_to_utf8(inputFile)
-            const fileContent = fileContentBuffer.toString()
-            const parsedData = await parsers[i](fileContent)
-            return parsedData
-        } catch (e: any) {
-            errors.push(e)
+    for (let j = 0; j < filesCopy.length; j++) {
+        for (let i = 0; i < parsers.length; i++) {
+            try {
+                const file = filesCopy[j].data?.toString().split(',')[1]
+                const inputFile = file ? file : ""
+                const fileContentBuffer = parsers[i].name === 'parseNordNetCSV' ? decodeUTF16LE(atob(inputFile)) : b64_to_utf8(inputFile)
+                const fileContent = fileContentBuffer.toString()
+                const parsedData = await parsers[i](fileContent)
+                return parsedData
+            } catch (e: any) {
+                errors.push(e)
+            }
         }
     }
     return [{ Source: "Error", Error: (errors.find(e => (e instanceof TypeError)) ?? errors[0]) }]

--- a/tests/transactions.test.ts
+++ b/tests/transactions.test.ts
@@ -138,23 +138,23 @@ describe('calculateFIFO', () => {
         transactions: [
           {
             ticker: "Yhtio Oy",
-            buydate: new Date('2015-01-01'),
-            selldate: new Date('2017-01-01'),
-            amountsold: 200,
-            transferPrice: 20,
-            profitOrLoss: -2000,
-            acquisitionPrice: 30,
-            acquisitionFee: 0,
-            transferFee: 0
-          },
-          {
-            ticker: "Yhtio Oy",
             buydate: new Date('2016-01-01'),
             selldate: new Date('2017-01-01'),
             amountsold: 800,
             transferPrice: 20,
             profitOrLoss: 6000,
             acquisitionPrice: 12.5,
+            acquisitionFee: 0,
+            transferFee: 0
+          },
+          {
+            ticker: "Yhtio Oy",
+            buydate: new Date('2015-01-01'),
+            selldate: new Date('2017-01-01'),
+            amountsold: 200,
+            transferPrice: 20,
+            profitOrLoss: -2000,
+            acquisitionPrice: 30,
             acquisitionFee: 0,
             transferFee: 0
           }
@@ -215,68 +215,68 @@ describe('calculateFIFO', () => {
         transactionFee: 0,
       },
     ]
-    const capitalGains = calculateFIFOCapitalGains(operationHistory)
-    expect(capitalGains).toEqual([
+    const capitalGains = JSON.stringify(calculateFIFOCapitalGains(operationHistory))
+    expect(JSON.parse(capitalGains)).toEqual([
       {
-        "capitalGainPerSellDate": 500,
-        "transactions": [
-          {
-            "ticker": "STK1",
-            "buydate": new Date("2020-01-01"),
-            "selldate": new Date("2020-03-01"),
-            "amountsold": 5,
-            "transferPrice": 200,
-            "profitOrLoss": 500,
-            "acquisitionPrice": 100,
-            "acquisitionFee": 0,
-            "transferFee": 0
-          }
-        ]
+          "capitalGainPerSellDate": 500,
+          "transactions": [
+              {
+                  "ticker": "STK1",
+                  "buydate": "2020-01-01T00:00:00.000Z",
+                  "selldate": "2020-03-01T00:00:00.000Z",
+                  "amountsold": 5,
+                  "transferPrice": 200,
+                  "profitOrLoss": 500,
+                  "acquisitionPrice": 100,
+                  "acquisitionFee": 0,
+                  "transferFee": 0
+              }
+          ]
       },
       {
-        "capitalGainPerSellDate": 500,
-        "transactions": [
-          {
-            "ticker": "STK2",
-            "buydate": new Date("2020-02-01"),
-            "selldate": new Date("2021-01-01"),
-            "amountsold": 10,
-            "transferPrice": 200,
-            "profitOrLoss": 500,
-            "acquisitionPrice": 150,
-            "acquisitionFee": 0,
-            "transferFee": 0
-          }
-        ]
+          "capitalGainPerSellDate": 500,
+          "transactions": [
+              {
+                  "ticker": "STK2",
+                  "buydate": "2020-02-01T00:00:00.000Z",
+                  "selldate": "2021-01-01T00:00:00.000Z",
+                  "amountsold": 10,
+                  "transferPrice": 200,
+                  "profitOrLoss": 500,
+                  "acquisitionPrice": 150,
+                  "acquisitionFee": 0,
+                  "transferFee": 0
+              }
+          ]
       },
       {
-        "capitalGainPerSellDate": 1500,
-        "transactions": [
-          {
-            "ticker": "STK1",
-            "buydate": new Date("2020-01-01"),
-            "selldate": new Date("2022-01-01"),
-            "amountsold": 5,
-            "transferPrice": 300,
-            "profitOrLoss": 1000,
-            "acquisitionPrice": 100,
-            "acquisitionFee": 0,
-            "transferFee": 0
-          },
-          {
-            "ticker": "STK1",
-            "buydate": new Date("2020-04-01"),
-            "selldate": new Date("2022-01-01"),
-            "amountsold": 10,
-            "transferPrice": 300,
-            "profitOrLoss": 500,
-            "acquisitionPrice": 250,
-            "acquisitionFee": 0,
-            "transferFee": 0
-          }
-        ]
+          "capitalGainPerSellDate": 1500,
+          "transactions": [
+              {
+                  "ticker": "STK1",
+                  "buydate": "2020-04-01T00:00:00.000Z",
+                  "selldate": "2022-01-01T00:00:00.000Z",
+                  "amountsold": 10,
+                  "transferPrice": 300,
+                  "profitOrLoss": 500,
+                  "acquisitionPrice": 250,
+                  "acquisitionFee": 0,
+                  "transferFee": 0
+              },
+              {
+                  "ticker": "STK1",
+                  "buydate": "2020-01-01T00:00:00.000Z",
+                  "selldate": "2022-01-01T00:00:00.000Z",
+                  "amountsold": 5,
+                  "transferPrice": 300,
+                  "profitOrLoss": 1000,
+                  "acquisitionPrice": 100,
+                  "acquisitionFee": 0,
+                  "transferFee": 0
+              }
+          ]
       }
-    ])
+  ])
   })
 
   it("throws when a symbol's sales have a bigger amount than its buys", () => {


### PR DESCRIPTION
Currently the parser loop is only ran for the first dropped file, hence making it impossible to drag and drop multiple files at once (one by one still works fine)